### PR TITLE
Use codecov instead of coveralls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,23 +70,11 @@ jobs:
       - name: Test
         run: npm run test:coverage
 
-      - name: Coveralls Parallel
-        uses: coverallsapp/github-action@v2
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        if: matrix.node_version == 22
         with:
-          format: lcov
-          file: "./coverage/lcov.info"
-          parallel: true
-          flag-name: run-node-${{matrix.node_version}}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Build
         run: npm pack
-
-  finish:
-    needs: test
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@v2
-        with:
-          parallel-finished: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use codecov for code coverage
+
 ## [0.1.0] - 2025-02-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GitHub Actions docs
 
 [![CI Status](https://github.com/stschulte/github-action-docs/workflows/CI/badge.svg)](https://github.com/stschulte/github-action-docs/actions/workflows/test.yml)
-[![Coverage Status](https://coveralls.io/repos/github/stschulte/github-action-docs/badge.svg?branch=main)](https://coveralls.io/github/stschulte/github-action-docs?branch=main)
+[![codecov](https://codecov.io/gh/stschulte/github-action-docs/graph/badge.svg?token=P43DANKS6I)](https://codecov.io/gh/stschulte/github-action-docs)
 [![npm version](https://badge.fury.io/js/github-action-docs.svg)](https://badge.fury.io/js/github-action-docs)
 
 Generate documentation with inputs and outputs from your `action.yml` file.


### PR DESCRIPTION
For whatever reason I am not able to add the repository to coveralls, so I am now using codecov.