### PR TITLE
Drop tslib dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Drop unnecessary `tslib` dependency.
+
 ## [1.0.0] - 2025-03-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "commander": "^13.1.0",
-        "tslib": "^2.8.1",
         "yaml": "^2.7.0"
       },
       "bin": {
@@ -3365,12 +3364,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "homepage": "https://github.com/stschulte/github-action-docs#readme",
   "dependencies": {
     "commander": "^13.1.0",
-    "tslib": "^2.8.1",
     "yaml": "^2.7.0"
   },
   "devDependencies": {

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -15,7 +15,6 @@ set -e
 
 RUNTIME_DEPENDENCIES=(
   "commander"
-  "tslib"
   "yaml"
 )
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,6 @@
     "strictNullChecks": true,
     "strict": true,
     "verbatimModuleSyntax": true,
+    "importHelpers": false
   }
 }


### PR DESCRIPTION
It looks like tslib is only necessary when using import helpers. It looks like we do not really rely on this feature as disabling import helpers seems to yield the same code.

So we now disable the helpers and drop the dependency.