### PR TITLE
Use pipe to prevent automatically handle write pushback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Internal rewrite to efficiently handle generating data
+
 ## [1.0.1] - 2025-03-04
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1576,9 +1576,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/src/merger.ts
+++ b/src/merger.ts
@@ -1,0 +1,33 @@
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
+
+const START_PATTERN = /<!-- BEGIN_GITHUB_ACTION_DOCS -->/;
+const END_PATTERN = /<!-- END_GITHUB_ACTION_DOCS -->/;
+
+export async function* merge(path: string, mergeIterator: Iterable<string>): AsyncGenerator<string, undefined, unknown> {
+  const rl = createInterface({
+    crlfDelay: Infinity,
+    input: createReadStream(path),
+  });
+
+  let shouldCopy = true;
+  for await (const line of rl) {
+    if (START_PATTERN.exec(line)) {
+      yield line;
+      yield '\n';
+      for (const chunk of mergeIterator) {
+        yield chunk;
+      }
+      shouldCopy = false;
+    }
+    else if (END_PATTERN.exec(line)) {
+      yield line;
+      yield '\n';
+      shouldCopy = true;
+    }
+    else if (shouldCopy) {
+      yield line;
+      yield '\n';
+    }
+  }
+}

--- a/src/stdoutStream.ts
+++ b/src/stdoutStream.ts
@@ -1,0 +1,9 @@
+import { Writable } from 'node:stream';
+
+export function stdoutStream() {
+  return new Writable({
+    write(chunk: string, encoding, callback) {
+      process.stdout.write(chunk, encoding, callback);
+    },
+  });
+}

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -78,7 +78,7 @@ describe('mdAnchor', () => {
 
 describe('generateMarkdownInputs', () => {
   it('create a heading with no inputs', () => {
-    expect(generateMarkdownInputs(undefined)).toStrictEqual(`## Inputs
+    expect(Array.from(generateMarkdownInputs(undefined)).join('')).toStrictEqual(`## Inputs
 
 (none)
 `);
@@ -87,13 +87,13 @@ describe('generateMarkdownInputs', () => {
   it('generates correct markdown', () => {
     const testdata = parse(readTestData('input-mixed.yml')) as Metadata['inputs'];
     const expectedResult = readTestData('input-mixed.md');
-    expect(generateMarkdownInputs(testdata)).toStrictEqual(expectedResult);
+    expect(Array.from(generateMarkdownInputs(testdata)).join('')).toStrictEqual(expectedResult);
   });
 });
 
 describe('generateMarkdownOutputs', () => {
   it('create a heading with no inputs', () => {
-    expect(generateMarkdownOutputs(undefined)).toStrictEqual(`## Outputs
+    expect(Array.from(generateMarkdownOutputs(undefined)).join('')).toStrictEqual(`## Outputs
 
 (none)
 `);
@@ -102,7 +102,7 @@ describe('generateMarkdownOutputs', () => {
   it('generates correct markdown', () => {
     const testdata = parse(readTestData('output-mixed.yml')) as Metadata['outputs'];
     const expectedResult = readTestData('output-mixed.md');
-    expect(generateMarkdownOutputs(testdata)).toStrictEqual(expectedResult);
+    expect(Array.from(generateMarkdownOutputs(testdata)).join('')).toStrictEqual(expectedResult);
   });
 });
 
@@ -111,7 +111,7 @@ describe('generateMarkdownType', () => {
     it('generates section with common attributes', () => {
       const testdata = parse(readTestData('type-nodejs.yml')) as MetadataJS['runs'];
       const expectedResult = readTestData('type-nodejs.md');
-      expect(generateMarkdownType(testdata)).toStrictEqual(expectedResult);
+      expect(Array.from(generateMarkdownType(testdata)).join('')).toStrictEqual(expectedResult);
     });
   });
 
@@ -119,7 +119,7 @@ describe('generateMarkdownType', () => {
     it('generates a section', () => {
       const testdata = parse(readTestData('type-composite.yml')) as MetadataComposite['runs'];
       const expectedResult = readTestData('type-composite.md');
-      expect(generateMarkdownType(testdata)).toStrictEqual(expectedResult);
+      expect(Array.from(generateMarkdownType(testdata)).join('')).toStrictEqual(expectedResult);
     });
   });
 
@@ -127,19 +127,19 @@ describe('generateMarkdownType', () => {
     it('generates a section when referencing a dockerfile', () => {
       const testdata = parse(readTestData('type-docker.yml')) as MetadataDocker['runs'];
       const expectedResult = readTestData('type-docker.md');
-      expect(generateMarkdownType(testdata)).toStrictEqual(expectedResult);
+      expect(Array.from(generateMarkdownType(testdata)).join('')).toStrictEqual(expectedResult);
     });
 
     it('generates a section when referencing an image', () => {
       const testdata = parse(readTestData('type-docker-alpine.yml')) as MetadataDocker['runs'];
       const expectedResult = readTestData('type-docker-alpine.md');
-      expect(generateMarkdownType(testdata)).toStrictEqual(expectedResult);
+      expect(Array.from(generateMarkdownType(testdata)).join('')).toStrictEqual(expectedResult);
     });
 
     it('lists environment variables', () => {
       const testdata = parse(readTestData('type-docker-env.yml')) as MetadataDocker['runs'];
       const expectedResult = readTestData('type-docker-env.md');
-      expect(generateMarkdownType(testdata)).toStrictEqual(expectedResult);
+      expect(Array.from(generateMarkdownType(testdata)).join('')).toStrictEqual(expectedResult);
     });
   });
 });
@@ -195,6 +195,6 @@ describe('generateMarkdown', () => {
   it('generates a valid documentation', () => {
     const testdata = parse(readTestData('example.yml')) as Metadata;
     const expectedResult = readTestData('example.md');
-    expect(generateMarkdown(testdata, ['type', 'inputs', 'outputs'])).toStrictEqual(expectedResult);
+    expect(Array.from(generateMarkdown(testdata, ['type', 'inputs', 'outputs'])).join('')).toStrictEqual(expectedResult);
   });
 });

--- a/tests/merger.test.ts
+++ b/tests/merger.test.ts
@@ -1,0 +1,44 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { merge } from '../src/merger.js';
+
+async function consumeAsyncIterator(it: AsyncIterable<string>): Promise<string> {
+  let result = '';
+  for await (const chunk of it) {
+    result += chunk;
+  }
+  return result;
+}
+
+describe('merge', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join('.', 'test-merger'));
+
+    return () => {
+      rmSync(tmpDir, { force: true, recursive: true });
+    };
+  });
+
+  it('merges file with an iterator between START_PATTERN and END_PATTERN', async () => {
+    const file = join(tmpDir, 'input.txt');
+    const data = 'Above One\nAbove Two\n<!-- BEGIN_GITHUB_ACTION_DOCS -->\nWill overwrite\n<!-- END_GITHUB_ACTION_DOCS -->\nBelow One\nBelow Two\n';
+    const it = ['Inject ', 'One\n', 'In', 'ject', ' Two\n'];
+
+    writeFileSync(file, data, { encoding: 'utf8' });
+
+    const result = await consumeAsyncIterator(merge(file, it));
+    expect(result).toBe(`Above One
+Above Two
+<!-- BEGIN_GITHUB_ACTION_DOCS -->
+Inject One
+Inject Two
+<!-- END_GITHUB_ACTION_DOCS -->
+Below One
+Below Two
+`);
+  });
+});

--- a/tests/stdoutStream.test.ts
+++ b/tests/stdoutStream.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { stdoutStream } from '../src/stdoutStream.js';
+
+describe('stdoutStream', () => {
+  it('provides a stream we can write to', async () => {
+    let data = '';
+
+    /* We mock stdout to just fill data */
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk, _encoding, callback) => {
+      data += chunk.toString();
+
+      if (callback) {
+        callback();
+      }
+      return true;
+    });
+
+    await new Promise((resolve, reject) => {
+      const stream = stdoutStream();
+      stream.write('Hello, ', 'utf8');
+      stream.write('World', 'utf8', (err) => {
+        if (err) {
+          reject(err);
+        }
+        else {
+          resolve(true);
+        }
+      });
+    });
+
+    expect(data).toStrictEqual('Hello, World');
+  });
+});


### PR DESCRIPTION
When writing to a stream (e.g. stdout or a file stream) we normally have to check the return value of each write to know wether or not we should continue writing or wait until the buffer is free again.

When using a pipe we do not have to do that.

We now rewrite our markdown generator function to act as a generator that yield chunks of markdown. This can be wrapped into a Readable that can then easily be piped into a write stream.

Node should then automatically handle to only generate new data when the write stream is actually ready to receive data.